### PR TITLE
Determine value type when processing parameters

### DIFF
--- a/src/VitessPdo/PDO/PDOStatement.php
+++ b/src/VitessPdo/PDO/PDOStatement.php
@@ -397,14 +397,14 @@ class PDOStatement
      * Binds a value to a corresponding named or question mark placeholder in the SQL statement that was used
      * to prepare the statement.
      *
-     * @param mixed $parameter - Parameter identifier. For a prepared statement using named placeholders, this will be
-     *                           a parameter name of the form :name. For a prepared statement using question mark
-     *                           placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed    $parameter - Parameter identifier. For a prepared statement using named placeholders, this will be
+     *                              a parameter name of the form :name. For a prepared statement using question mark
+     *                              placeholders, this will be the 1-indexed position of the parameter.
      *
-     * @param mixed $value     - The value to bind to the parameter.
-     * @param null|int $dataType    - The value to bind to the parameter.
+     * @param mixed    $value     - The value to bind to the parameter.
+     * @param null|int $dataType  - The value to bind to the parameter.
      *
-     * @return bool            - Returns TRUE on success or FALSE on failure.
+     * @return bool               - Returns TRUE on success or FALSE on failure.
      */
     public function bindValue($parameter, $value, $dataType = null)
     {

--- a/src/VitessPdo/PDO/PDOStatement.php
+++ b/src/VitessPdo/PDO/PDOStatement.php
@@ -397,8 +397,8 @@ class PDOStatement
      * Binds a value to a corresponding named or question mark placeholder in the SQL statement that was used
      * to prepare the statement.
      *
-     * @param mixed    $parameter - Parameter identifier. For a prepared statement using named placeholders, this will be
-     *                              a parameter name of the form :name. For a prepared statement using question mark
+     * @param mixed $parameter      - Parameter identifier. For a prepared statement using named placeholders, this will
+     *                              be a parameter name of the form :name. For a prepared statement using question mark
      *                              placeholders, this will be the 1-indexed position of the parameter.
      *
      * @param mixed    $value     - The value to bind to the parameter.

--- a/src/VitessPdo/PDO/PDOStatement.php
+++ b/src/VitessPdo/PDO/PDOStatement.php
@@ -402,11 +402,11 @@ class PDOStatement
      *                           placeholders, this will be the 1-indexed position of the parameter.
      *
      * @param mixed $value     - The value to bind to the parameter.
-     * @param int $dataType    - The value to bind to the parameter.
+     * @param null|int $dataType    - The value to bind to the parameter.
      *
      * @return bool            - Returns TRUE on success or FALSE on failure.
      */
-    public function bindValue($parameter, $value, $dataType = CorePDO::PARAM_STR)
+    public function bindValue($parameter, $value, $dataType = null)
     {
         try {
             if (is_int($parameter)) {

--- a/src/VitessPdo/PDO/ParamProcessor.php
+++ b/src/VitessPdo/PDO/ParamProcessor.php
@@ -63,14 +63,18 @@ class ParamProcessor
     ];
 
     /**
-     * @param mixed $value
-     * @param int   $type
+     * @param mixed    $value
+     * @param null|int $type
      *
      * @return mixed
      * @throws Exception
      */
-    public function process($value, $type = CorePDO::PARAM_STR)
+    public function process($value, $type = null)
     {
+        if (is_null($type)) {
+            $type = $this->determineValueType($value);
+        }
+
         $handler = $this->getHandler($type);
 
         return $this->{$handler}($value);
@@ -105,6 +109,35 @@ class ParamProcessor
         }
 
         return self::$typeHandlers[$type];
+    }
+
+    /**
+     * @param $value
+     *
+     * @return int
+     */
+    private function determineValueType($value){
+            switch (gettype($value)) {
+                case 'boolean':
+                    $type = CorePDO::PARAM_BOOL;
+                    break;
+                case 'integer':
+                    $type = CorePDO::PARAM_INT;
+                    break;
+                case 'NULL':
+                    $type = CorePDO::PARAM_NULL;
+                    break;
+                case 'double':
+                case 'string':
+                case 'array':
+                case 'object':
+                case 'resource':
+                case 'unknown type':
+                default:
+                    $type = CorePDO::PARAM_STR;
+            }
+
+            return $type;
     }
 
     /**


### PR DESCRIPTION
This is a pull request to fix issue #9 

This will allow any type of value to be passed into `PDOStatement::bindValue()` and ,if possible, it will detect and set the type of the value.  If a type is passed into the function, it will act as normal.
