### PR TITLE
Add type checking to bindValue if $dataType is defaulted

### DIFF
--- a/src/VitessPdo/PDO/PDOStatement.php
+++ b/src/VitessPdo/PDO/PDOStatement.php
@@ -407,18 +407,36 @@ class PDOStatement
      * Binds a value to a corresponding named or question mark placeholder in the SQL statement that was used
      * to prepare the statement.
      *
-     * @param mixed $parameter - Parameter identifier. For a prepared statement using named placeholders, this will be
-     *                           a parameter name of the form :name. For a prepared statement using question mark
-     *                           placeholders, this will be the 1-indexed position of the parameter.
+     * @param mixed $parameter     - Parameter identifier. For a prepared statement using named placeholders, this will
+     *                               be a parameter name of the form :name. For a prepared statement using question mark
+     *                               placeholders, this will be the 1-indexed position of the parameter.
      *
-     * @param mixed $value     - The value to bind to the parameter.
-     * @param int $dataType    - The value to bind to the parameter.
+     * @param mixed $value         - The value to bind to the parameter.
+     * @param int   $dataType      - Explicit data type for the parameter using the CorePDO::PARAM_* constants. If this
+     *                               parameter defaults to CorePDO::PARAM_STR, the type of the value will be analyzed
+     *                               and possibly changed
      *
-     * @return bool            - Returns TRUE on success or FALSE on failure.
+     * @return bool                - Returns TRUE on success or FALSE on failure.
      */
     public function bindValue($parameter, $value, $dataType = CorePDO::PARAM_STR)
     {
         try {
+            if (func_num_args() == 2) {
+                switch (gettype($value)) {
+                    case 'boolean':
+                        $dataType = CorePDO::PARAM_BOOL;
+                        break;
+                    case 'integer':
+                        $dataType = CorePDO::PARAM_INT;
+                        break;
+                    case 'NULL':
+                        $dataType = CorePDO::PARAM_NULL;
+                        break;
+                    default:
+                        $dataType = CorePDO::PARAM_STR;
+                }
+            }
+
             if (is_int($parameter)) {
                 $parameter = "v{$parameter}";
             }


### PR DESCRIPTION
> **LTDR;** If you try and execute a command with a binding set to `null` (Issue #9), it will be cast into a string by default.  This can cause exceptions when running the query.
## Overview

When a query is being prepared and a parameters `data_type` is not passed into PDOStatement::bindValue, it defaults to the `data_type` String.  This functionality would cause boolean, null, and integer parameters to be cast as a String.
## Example Exception Case

Table `profile` has a column named `deleted_at` that is of type DateTime and is Nullable.  When a query sets `deleted_at` to `null` then is executed, an invalid DateTime exception will be thrown.
## Research
- When performing the same query using PHP's PDO extension (connected to a MySql instance) parameter types are properly accounted for when passed into PDOStatement::execute OR PDOStatement::bindValue.
- Link to PHP extension code PDOStatement::really_register_bound_param https://github.com/php/php-src/blob/master/ext/pdo/pdo_stmt.c#L290
