### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/VitessPdoTest/PDO/Dsn/ConfigTest.php
+++ b/tests/VitessPdoTest/PDO/Dsn/ConfigTest.php
@@ -20,13 +20,14 @@ namespace VitessPdoTest\PDO\Dsn;
 use VitessPdo\PDO\Dsn\Config;
 use VitessPdo\PDO\Exception as DriverException;
 use Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigTest
  *
  * @package VitessPdoTest\PDO\Dsn
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
 
     /**

--- a/tests/VitessPdoTest/PDO/Dsn/DriverTest.php
+++ b/tests/VitessPdoTest/PDO/Dsn/DriverTest.php
@@ -20,13 +20,14 @@ namespace VitessPdoTest\PDO\Dsn;
 use VitessPdo\PDO\Dsn\Driver;
 use VitessPdo\PDO\Exception as DriverException;
 use Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DriverTest
  *
  * @package VitessPdoTest\PDO\Dsn
  */
-class DriverTest extends \PHPUnit_Framework_TestCase
+class DriverTest extends TestCase
 {
 
     /**

--- a/tests/VitessPdoTest/PDO/DsnTest.php
+++ b/tests/VitessPdoTest/PDO/DsnTest.php
@@ -20,13 +20,14 @@ namespace VitessPdoTest\PDO;
 use VitessPdo\PDO\Dsn\Dsn;
 use VitessPdo\PDO\Exception as DriverException;
 use Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DsnTest
  *
  * @package VitessPdoTest\PDO
  */
-class DsnTest extends \PHPUnit_Framework_TestCase
+class DsnTest extends TestCase
 {
 
     /**

--- a/tests/VitessPdoTest/PDO/PDOStatementTest.php
+++ b/tests/VitessPdoTest/PDO/PDOStatementTest.php
@@ -29,6 +29,7 @@ use VitessPdo\PDO\PDOStatement;
 use VitessPdo\PDO\Exception as VitessPDOException;
 use Exception;
 use PDO as CorePDO;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PDOStatementTest
@@ -37,7 +38,7 @@ use PDO as CorePDO;
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class PDOStatementTest extends \PHPUnit_Framework_TestCase
+class PDOStatementTest extends TestCase
 {
 
     /**

--- a/tests/VitessPdoTest/PDO/ParamProcessorTest.php
+++ b/tests/VitessPdoTest/PDO/ParamProcessorTest.php
@@ -19,13 +19,14 @@ namespace VitessPdoTest\PDO;
 
 use VitessPdo\PDO\ParamProcessor;
 use PDO as CorePDO;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ParamProcessorTest
  * @author mfris
  * @package VitessPdo\PDO
  */
-class ParamProcessorTest extends \PHPUnit_Framework_TestCase
+class ParamProcessorTest extends TestCase
 {
 
     /**

--- a/tests/VitessPdoTest/PDO/QueryAnalyzerTest.php
+++ b/tests/VitessPdoTest/PDO/QueryAnalyzerTest.php
@@ -18,13 +18,14 @@
 namespace VitessPdoTest\PDO;
 
 use VitessPdo\PDO\QueryAnalyzer\Analyzer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class QueryAnalyzerTest
  *
  * @package VitessPdoTest\PDO
  */
-class QueryAnalyzerTest extends \PHPUnit_Framework_TestCase
+class QueryAnalyzerTest extends TestCase
 {
 
     /**"SELECT * FROM user"

--- a/tests/VitessPdoTest/PDOTest.php
+++ b/tests/VitessPdoTest/PDOTest.php
@@ -25,6 +25,7 @@ use VitessPdoTest\Helper\VTComboRunner;
 use Exception;
 use PDOException;
 use PDO as CorePDO;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PDOTest
@@ -37,7 +38,7 @@ use PDO as CorePDO;
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  */
-class PDOTest extends \PHPUnit_Framework_TestCase
+class PDOTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).